### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ List of podcasts which are helpful for software engineers/programmers.
 - [CppCast](http://cppcast.com/)
 
   - <b>Description</b>: All about C++ and many great interviews with prominent library and tool authors.
-  - <b>Frequency</b>  : Weekly
+  - <b>Frequency</b>  : Once every week
 
 
 ## Data/MachineLearning
@@ -32,11 +32,15 @@ List of podcasts which are helpful for software engineers/programmers.
 ## Devops
 
 - [Arrested DevOps](https://www.arresteddevops.com/)
+  - <b>Description</b>: ADO helps you understand and develop good DevOps practices. 
+  - <b>Frequency</b>  : Varies
 
 
 ## Functional Programming
 
 - [Elm Town](https://elmtown.audio/)
+  - <b>Description</b>: About the people making and using the Elm language.
+  - <b>Frequency</b>  : Varies
 
 - [FunctionalGeekery](https://www.functionalgeekery.com/)
   - <b>Description</b>: All functional programming languages


### PR DESCRIPTION
Made the terms used for frequency consistent. Changed frequency description from "weekly" to "once every week" for CppCast.   
Also added the description for ElmTown and ArrestedDevOps podcasts. A new frequency term "Varies" is used when the podcast does not release episodes after fixed time intervals.

Before raising a PR and it getting merged, make sure you have completed the following:

### Things to do:

- [x] Add podcasts in appropriate categories in ascending order of podcast name
- [x] If there is no matching category, add a new category to the list in ascending order of category name
- [x] Add a brief description of the podcast
- [x] Add the frequency of episodes (Check the list for examples)

Thanks for your contributions and being awesome :) Cheers.
