### PR TITLE
Add .NET Rocks podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 List of podcasts which are helpful for software engineers/programmers.
 
+## .NET
+
+- [.NET Rocks](https://www.dotnetrocks.com/)
+
+  - <b>description</b>: Show about all things related to programming in .NET.
+  - <b>Frequency</b>: Once every week
+
 ## Android
 
 - [Android Developers Backstage](http://feeds.feedburner.com/blogspot/AndroidDevelopersBackstage)


### PR DESCRIPTION
Added the .NET Rocks podcast under the .NET heading.


Before raising a PR and it getting merged, make sure you have completed the following:
### Things to do:

- [x] Add podcasts in appropriate categories in ascending order of podcast name
- [x] If there is no matching category, add a new category to the list in ascending order of category name
- [x] Add a brief description of the podcast
- [x] Add the frequency of episodes (Check the list for examples)
