### PR TITLE
Add programming throwdown podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ List of podcasts which are helpful for software engineers/programmers.
 
 - [Programming and Performance with Cliff Click](https://itunes.apple.com/us/podcast/programming-and-performance-with-cliff-click/id1286422919)
 
+- [Programming Throwdown](http://www.programmingthrowdown.com/)
+  - <b>Description</b>: Anything and everything related to software
+  - <b>Frequency</b>: Once per month
+
 - [Software Engineering Daily](https://softwareengineeringdaily.com/)
   - <b>Description</b>: Podcasts on technical software topics
   - <b>Frequency</b>  : Multiple episodes every week


### PR DESCRIPTION
### Context
Add programming throwdown podcast. -> http://www.programmingthrowdown.com/

### Things to do:

- [x] Add podcasts in appropriate categories in ascending order of podcast name
- [x] If there is no matching category, add a new category to the list in ascending order of category name
- [x] Add a brief description of the podcast
- [x] Add the frequency of episodes (Check the list for examples)
