### PR TITLE
Add table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 List of podcasts which are helpful for software engineers/programmers.
 
+## Table of Contents
+
+- [.NET](#net)
+- [Agile](#agile)
+- [Android](#android)
+- [Angular](#angular)
+- [C++](#c)
+- [Data Science/Machine Learning](#data-sciencemachine-learning)
+- [Devops](#devops)
+- [Functional Programming](#functional-programming)
+- [General Software](#general-software)
+- [Go Programming Language](#go-programming-language)
+- [Python](#python)
+- [ReasonML](#reasonml)
+- [Ruby/Rails](#rubyrails)
+- [Kotlin](#kotlin)
+- [Java](#java)
+- [Swift](#swift)
+- [Rust Programming Language](#rust-programming-language)
+- [Security](#security)
+- [Web development](#web-development)
+
 ## .NET
 
 - [.NET Rocks](https://www.dotnetrocks.com/)

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -3,7 +3,7 @@ Before raising a PR and it getting merged, make sure you have completed the foll
 ### Things to do:
 
 - [ ] Add podcasts in appropriate categories in ascending order of podcast name
-- [ ] If there is no matching category, add a new category to the list in ascending order of category name
+- [ ] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
 - [ ] Add a brief description of the podcast
 - [ ] Add the frequency of episodes (Check the list for examples)
 


### PR DESCRIPTION
Hey! Neat idea 👍

This PR Adds a table of contents for easy navigation of categories.

---

The following don't apply as I'm not adding a podcast :)

### Things to do:

- [ ] Add podcasts in appropriate categories in ascending order of podcast name
- [ ] If there is no matching category, add a new category to the list in ascending order of category name
- [ ] Add a brief description of the podcast
- [ ] Add the frequency of episodes (Check the list for examples)

Thanks for your contributions and being awesome :) Cheers.
