### PR TITLE
Add Full Stack Cast

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Description**: Technology with a free software / open source slant, crossing over into related political topics. Evolution of the now-defunct [LugRadio](https://en.wikipedia.org/wiki/LugRadio) podcast.
   * **Frequency**: Monthly twice
   * **Runtime**: 50 - 80 mins, regularly ~70 mins
+  
+* [Full Stack Cast](https://podcast.fullstackfest.com/)
+
+  * **Description**: Interviews to past and future speakers of the Full Stack Fest conference, focusing on personal experiences and their personal journeys.
+  * **Frequency**: Monthly
+  * **Runtime**: 50 - 80 mins
 
 * [Greater than Code](https://www.greaterthancode.com/)
 


### PR DESCRIPTION
Adds Full Stack Cast - disclaimer, I'm one of the organitzers of the conference but I honestly think there's value in the podcast.

### Things to do:

- [x] Add podcasts in appropriate categories in ascending order of podcast name
- [x] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
- [x] Add a brief description of the podcast
- [x] Add the frequency of episodes (Check the list for examples)
- [x] Add the runtime of episodes, giving an approximate range and an average duration.

Thanks for your contributions and being awesome :) Cheers.
