### PR TITLE
Add infosec podcasts

### DIFF
--- a/DE.md
+++ b/DE.md
@@ -10,6 +10,6 @@ Eine Liste von Podcasts, die hilfreich für Software Entwickler und Programmiere
 
 * [Working Draft](https://workingdraft.de/)
 
-  * **Description**: Wöchentlicher News-Podcast für Webdesigner und -entwickler
-  * **Frequency** : Einmal in der Woche
-  * **Runtime**: 25 - 70 mins, regularly ~50 mins
+  * **Beschreibung**: Wöchentlicher News-Podcast für Webdesigner und -entwickler
+  * **Häufigkeit** : Einmal in der Woche
+  * **Laufzeit**: 25 - 70 min, regulär ~50 min

--- a/DE.md
+++ b/DE.md
@@ -1,0 +1,15 @@
+# Geniale Liste von wichtigen Podcats für Software Entwickler
+
+Eine Liste von Podcasts, die hilfreich für Software Entwickler und Programmierer sind.
+
+## Übersicht
+
+* [Webentwicklung](#webentwicklung)
+
+## Webentwicklung
+
+* [Working Draft](https://workingdraft.de/)
+
+  * **Description**: Wöchentlicher News-Podcast für Webdesigner und -entwickler
+  * **Frequency** : Einmal in der Woche
+  * **Runtime**: 25 - 70 mins, regularly ~50 mins

--- a/ES.md
+++ b/ES.md
@@ -1,0 +1,13 @@
+# Lista impresionante de Podcasts importantes para ingenieros de software
+
+Una lista de podcasts que puede ser útil para programadores e ingenieros de software.
+
+
+* [Desarrollo y programación](#desarrollo-y-programacion)
+
+### Desarrollo y programación
+
+* [Web Reactiva](https://www.danielprimo.io/podcast)
+  * **Descripción**: Cada semana un tema sobre desarrollo web y programación. Incluye entrevistas y pequeñas fábulas relacionadas con la tecnología. Porque la tecnología es necesaria pero las personas somos lo importante.
+  * **Frecuencia**: Semanalmente.
+  * **Duración**: 30 - 40 min

--- a/README.md
+++ b/README.md
@@ -767,9 +767,9 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Runtime**: 40 - 60 mins
 
 * [Security in Five](https://www.binaryblogger.com/)
-  **Description:**: Security In 5 brings you security news, tips and opinions on information IT and general security in about five minutes. Straight and to the point information in a timeframe you can easily listen to in one sitting. Whether you are a security professional or someone that wants to keep personal data safe this podcast will cover everyone. Be aware, be safe, welcome to Security In 5.
-  **Frequency**: Daily
-  **Runtime**: 5-10 Minutes
+  * **Description:**: Security In 5 brings you security news, tips and opinions on information IT and general security in about five minutes. Straight and to the point information in a timeframe you can easily listen to in one sitting. Whether you are a security professional or someone that wants to keep personal data safe this podcast will cover everyone. Be aware, be safe, welcome to Security In 5.
+  * **Frequency**: Daily
+  * **Runtime**: 5-10 Minutes
 
 * [Smashing Security](http://www.smashingsecurity.com/)
   * **Description**: Join computer security industry veterans Graham Cluley and Carole Theriault as they have a light-hearted chat with guests about cybercrime, hacking, and online privacy. It's not your typical cybersecurity podcast... Winner: "Best Security Podcast 2018." Follow the podcast on Twitter at @SmashinSecurity. New episodes released every Thursday. Bonus "splinter" episodes when we feel like it...

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ List of podcasts which are helpful for software engineers/programmers.
 * [Git](#git)
 * [Go Programming Language](#go-programming-language)
 * [Groovy](#groovy)
+* [InfoSec](#infosec)
 * [iOS](#ios)
 * [Java](#java)
 * [JavaScript](#javascript)
@@ -732,6 +733,33 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Description**: A podcast dedicated to the Groovy programming language and its ecosystem.
   * **Frequency**: Approximately once a month
   * **Runtime**: 20 - 70 mins, regularly ~50 mins
+
+## InfoSec
+* [Security in Five]()
+  **Description:**: Small pieces about all things cyber-security. 
+  **Frequency**: Almost daily
+  **Runtime**: 5-10 Minutes
+
+* [Risky.Biz]()
+
+* [Smashing Security]()
+
+* [Brakeing Down Security]()
+
+* [Darknet Diaries[()
+
+* [Defensive Security]()
+
+* [Malicious Life]()
+
+* [The Many Hats Club]()
+
+* [Purple Squad Security]()
+
+* [The Social-Engineer Podcast]()
+
+* [Unsupervised Learning]()
+ 
 
 ## iOS
 

--- a/README.md
+++ b/README.md
@@ -735,31 +735,62 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Runtime**: 20 - 70 mins, regularly ~50 mins
 
 ## InfoSec
-* [Security in Five]()
-  **Description:**: Small pieces about all things cyber-security. 
-  **Frequency**: Almost daily
+
+* [Brakeing Down Security](http://www.brakeingsecurity.com/)
+  * **Description**: A podcast all about the world of Security, Privacy, Compliance, and Regulatory issues that arise in today's workplace. Co-hosts Bryan Brake, Amanda Berlin, and Brian Boettcher teach concepts that aspiring Information Security Professionals need to know, or refresh the memories of the seasoned veterans.
+  * **Frequency**: Weekly
+  * **Runtime**: Approximately 1 hour
+
+* [Darknet Diaries](https://darknetdiaries.com/)
+  * **Description**: Explore the dark side of the Internet with host Jack Rhysider as he takes you on a journey through the chilling world of privacy hacks, data breaches, and cyber crime. The masterful criminal hackers who dwell on the dark side show us just how vulnerable we all are.
+  * **Frequency**: Fortnightly
+  * **Runtime**: 20 - 40 mins
+  
+* [Defensive Security](https://defensivesecurity.org/)
+  * **Description**: Defensive Security is a weekly information security podcast which reviews recent high profile cyber security breaches, data breaches, malware infections and intrusions to identify lessons that we can learn and apply to the organizations we protect.
+  * **Frequency**: Fortnightly
+  * **Runtime**: 40 - 60 mins
+
+* [Malicious Life](https://malicious.life/)
+  * **Description**: Tales of cybersecurity. The wildest hacks you can ever imagine, told by people who were actually there. Hosted by cybersecurity expert and book author, Ran Levi, this is not your average talk-show. These are fascinating, unknown tales, slowly unraveled, deeply researched. Think Hardcore History meets Hackable- and come dig into a history you never knew existed.
+  * **Frequency**: Fortnightly
+  * **Runtime**: 30 - 45 mins
+      
+* [Purple Squad Security](https://purplesquadsec.com/)
+  * **Description**: Information Security, InfoSec, CyberSec, Cyber, Security, whatever you call it, we talk about it! From mobiles and desktops to data centers and the cloud, Purple Squad Security is here to help and give back to our community of information security professionals.
+  * **Frequency**: Weekly
+  * **Runtime**: 30 - 60 mins
+  
+* [Risky.Biz](https://risky.biz/)
+  * **Description**: Risky Business is a weekly information security podcast featuring news and in-depth interviews with industry luminaries. Launched in February 2007, Risky Business is a must-listen digest for information security pros. With a running time of approximately 50-60 minutes, Risky Business is pacy; a security podcast without the waffle.
+  * **Frequency**: Weekly
+  * **Runtime**: 40 - 60 mins
+
+* [Security in Five](https://www.binaryblogger.com/)
+  **Description:**: Security In 5 brings you security news, tips and opinions on information IT and general security in about five minutes. Straight and to the point information in a timeframe you can easily listen to in one sitting. Whether you are a security professional or someone that wants to keep personal data safe this podcast will cover everyone. Be aware, be safe, welcome to Security In 5.
+  **Frequency**: Daily
   **Runtime**: 5-10 Minutes
 
-* [Risky.Biz]()
+* [Smashing Security](http://www.smashingsecurity.com/)
+  * **Description**: Join computer security industry veterans Graham Cluley and Carole Theriault as they have a light-hearted chat with guests about cybercrime, hacking, and online privacy. It's not your typical cybersecurity podcast... Winner: "Best Security Podcast 2018." Follow the podcast on Twitter at @SmashinSecurity. New episodes released every Thursday. Bonus "splinter" episodes when we feel like it...
+  * **Frequency**: Weekly
+  * **Runtime**: 45 - 60 mins
 
-* [Smashing Security]()
-
-* [Brakeing Down Security]()
-
-* [Darknet Diaries[()
-
-* [Defensive Security]()
-
-* [Malicious Life]()
-
-* [The Many Hats Club]()
-
-* [Purple Squad Security]()
-
-* [The Social-Engineer Podcast]()
-
-* [Unsupervised Learning]()
- 
+* [The Many Hats Club](https://themanyhats.club/)
+  * **Description**: An information security focused group of individuals from all walks of life
+  * **Frequency**: Irregular
+  * **Runtime**: Approximately 2 hours
+  
+* [The Social-Engineer Podcast](http://www.social-engineer.org/category/podcast/)
+  * **Description**: The Social-Engineer Podcast is about humans. Understanding how we interact, communicate and relay information can help us protect, mitigate and understand social engineering attacks
+  * **Frequency**: Monthly
+  * **Runtime**: Approximately 60 mins
+  
+* [Unsupervised Learning](https://danielmiessler.com/podcast/)
+  * **Description**: I spend between five and twenty hours a week consuming articles, books, and podcasts looking for the most interesting ideas around security, technology, and how they interact with us as humans. Each episode is either a curated summary of what I’ve found in the past week, or a standalone essay that hopefully gives you something to think about.
+  * **Frequency**: Usually 15 - 30 mins, sometimes up to an hour
+  * **Runtime**: Bi-Weekly, Weekly for subscribers
+  
 
 ## iOS
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ List of podcasts which are helpful for software engineers/programmers.
 * [Git](#git)
 * [Go Programming Language](#go-programming-language)
 * [Groovy](#groovy)
-* [InfoSec](#infosec)
 * [iOS](#ios)
 * [Java](#java)
 * [JavaScript](#javascript)
@@ -734,64 +733,6 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Frequency**: Approximately once a month
   * **Runtime**: 20 - 70 mins, regularly ~50 mins
 
-## InfoSec
-
-* [Brakeing Down Security](http://www.brakeingsecurity.com/)
-  * **Description**: A podcast all about the world of Security, Privacy, Compliance, and Regulatory issues that arise in today's workplace. Co-hosts Bryan Brake, Amanda Berlin, and Brian Boettcher teach concepts that aspiring Information Security Professionals need to know, or refresh the memories of the seasoned veterans.
-  * **Frequency**: Weekly
-  * **Runtime**: Approximately 1 hour
-
-* [Darknet Diaries](https://darknetdiaries.com/)
-  * **Description**: Explore the dark side of the Internet with host Jack Rhysider as he takes you on a journey through the chilling world of privacy hacks, data breaches, and cyber crime. The masterful criminal hackers who dwell on the dark side show us just how vulnerable we all are.
-  * **Frequency**: Fortnightly
-  * **Runtime**: 20 - 40 mins
-  
-* [Defensive Security](https://defensivesecurity.org/)
-  * **Description**: Defensive Security is a weekly information security podcast which reviews recent high profile cyber security breaches, data breaches, malware infections and intrusions to identify lessons that we can learn and apply to the organizations we protect.
-  * **Frequency**: Fortnightly
-  * **Runtime**: 40 - 60 mins
-
-* [Malicious Life](https://malicious.life/)
-  * **Description**: Tales of cybersecurity. The wildest hacks you can ever imagine, told by people who were actually there. Hosted by cybersecurity expert and book author, Ran Levi, this is not your average talk-show. These are fascinating, unknown tales, slowly unraveled, deeply researched. Think Hardcore History meets Hackable- and come dig into a history you never knew existed.
-  * **Frequency**: Fortnightly
-  * **Runtime**: 30 - 45 mins
-      
-* [Purple Squad Security](https://purplesquadsec.com/)
-  * **Description**: Information Security, InfoSec, CyberSec, Cyber, Security, whatever you call it, we talk about it! From mobiles and desktops to data centers and the cloud, Purple Squad Security is here to help and give back to our community of information security professionals.
-  * **Frequency**: Weekly
-  * **Runtime**: 30 - 60 mins
-  
-* [Risky.Biz](https://risky.biz/)
-  * **Description**: Risky Business is a weekly information security podcast featuring news and in-depth interviews with industry luminaries. Launched in February 2007, Risky Business is a must-listen digest for information security pros. With a running time of approximately 50-60 minutes, Risky Business is pacy; a security podcast without the waffle.
-  * **Frequency**: Weekly
-  * **Runtime**: 40 - 60 mins
-
-* [Security in Five](https://www.binaryblogger.com/)
-  * **Description:**: Security In 5 brings you security news, tips and opinions on information IT and general security in about five minutes. Straight and to the point information in a timeframe you can easily listen to in one sitting. Whether you are a security professional or someone that wants to keep personal data safe this podcast will cover everyone. Be aware, be safe, welcome to Security In 5.
-  * **Frequency**: Daily
-  * **Runtime**: 5-10 Minutes
-
-* [Smashing Security](http://www.smashingsecurity.com/)
-  * **Description**: Join computer security industry veterans Graham Cluley and Carole Theriault as they have a light-hearted chat with guests about cybercrime, hacking, and online privacy. It's not your typical cybersecurity podcast... Winner: "Best Security Podcast 2018." Follow the podcast on Twitter at @SmashinSecurity. New episodes released every Thursday. Bonus "splinter" episodes when we feel like it...
-  * **Frequency**: Weekly
-  * **Runtime**: 45 - 60 mins
-
-* [The Many Hats Club](https://themanyhats.club/)
-  * **Description**: An information security focused group of individuals from all walks of life
-  * **Frequency**: Irregular
-  * **Runtime**: Approximately 2 hours
-  
-* [The Social-Engineer Podcast](http://www.social-engineer.org/category/podcast/)
-  * **Description**: The Social-Engineer Podcast is about humans. Understanding how we interact, communicate and relay information can help us protect, mitigate and understand social engineering attacks
-  * **Frequency**: Monthly
-  * **Runtime**: Approximately 60 mins
-  
-* [Unsupervised Learning](https://danielmiessler.com/podcast/)
-  * **Description**: I spend between five and twenty hours a week consuming articles, books, and podcasts looking for the most interesting ideas around security, technology, and how they interact with us as humans. Each episode is either a curated summary of what I’ve found in the past week, or a standalone essay that hopefully gives you something to think about.
-  * **Frequency**: Usually 15 - 30 mins, sometimes up to an hour
-  * **Runtime**: Bi-Weekly, Weekly for subscribers
-  
-
 ## iOS
 
 * [iPhreaks](https://devchat.tv/iphreaks)
@@ -1098,6 +1039,11 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Frequency** :  Weekly
   * **Runtime**: 25 - 40 mins, regularly ~30 mins
 
+* [Brakeing Down Security](http://www.brakeingsecurity.com/)
+  * **Description**: A podcast all about the world of Security, Privacy, Compliance, and Regulatory issues that arise in today's workplace. Co-hosts Bryan Brake, Amanda Berlin, and Brian Boettcher teach concepts that aspiring Information Security Professionals need to know, or refresh the memories of the seasoned veterans.
+  * **Frequency**: Weekly
+  * **Runtime**: Approximately 1 hour
+
 * [Breach](https://www.carbonite.com/podcasts/breach/)
   * **Description**: A podcast exploring data breaches and cybersecurity by Carbonite.
   * **Frequency** : Every 2/3 Months
@@ -1116,12 +1062,16 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Frequency**: Bi-weekly
   * **Runtime**: ~45 mins
 
-
 * [Defensive Security Podcast](https://defensivesecurity.org/)
 
   * **Description**: A cyber security podcast covering breaches and strategies for defense. An attempt to look at recent security news and pick out lessons to apply organizations we are charged with keeping secure.
   * **Frequency**: Various
   * **Runtime**: 20 - 105 mins, regularly ~50 mins
+
+* [Malicious Life](https://malicious.life/)
+  * **Description**: Tales of cybersecurity. The wildest hacks you can ever imagine, told by people who were actually there. Hosted by cybersecurity expert and book author, Ran Levi, this is not your average talk-show. These are fascinating, unknown tales, slowly unraveled, deeply researched. Think Hardcore History meets Hackable- and come dig into a history you never knew existed.
+  * **Frequency**: Fortnightly
+  * **Runtime**: 30 - 45 mins
 
 * [OWASP 24/7](https://www.owasp.org/index.php/OWASP_Podcast)
 
@@ -1135,11 +1085,22 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Frequency** : Once every week
   * **Runtime**: _various_
 
+  
+* [Purple Squad Security](https://purplesquadsec.com/)
+  * **Description**: Information Security, InfoSec, CyberSec, Cyber, Security, whatever you call it, we talk about it! From mobiles and desktops to data centers and the cloud, Purple Squad Security is here to help and give back to our community of information security professionals.
+  * **Frequency**: Weekly
+  * **Runtime**: 30 - 60 mins
+  
 * [Risky Business](https://risky.biz/netcasts/risky-business/)
 
   * **Description**: Information security podcast featuring news and in-depth interviews with industry luminaries.
   * **Frequency**: Weekly
   * **Runtime**: 30 - 70 mins, regularly ~60 mins
+
+* [Security in Five](https://www.binaryblogger.com/)
+  * **Description:**: Security In 5 brings you security news, tips and opinions on information IT and general security in about five minutes. Straight and to the point information in a timeframe you can easily listen to in one sitting. Whether you are a security professional or someone that wants to keep personal data safe this podcast will cover everyone. Be aware, be safe, welcome to Security In 5.
+  * **Frequency**: Daily
+  * **Runtime**: 5-10 Minutes
 
 * [Security Now](https://twit.tv/shows/security-now)
 
@@ -1152,6 +1113,26 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Frequency**: Once every 2/3 month
   * **Runtime**: 25 - 45 mins, regularly ~35 mins
 
+* [Smashing Security](http://www.smashingsecurity.com/)
+  * **Description**: Join computer security industry veterans Graham Cluley and Carole Theriault as they have a light-hearted chat with guests about cybercrime, hacking, and online privacy. It's not your typical cybersecurity podcast... Winner: "Best Security Podcast 2018." Follow the podcast on Twitter at @SmashinSecurity. New episodes released every Thursday. Bonus "splinter" episodes when we feel like it...
+  * **Frequency**: Weekly
+  * **Runtime**: 45 - 60 mins
+
+* [The Many Hats Club](https://themanyhats.club/)
+  * **Description**: An information security focused group of individuals from all walks of life
+  * **Frequency**: Irregular
+  * **Runtime**: Approximately 2 hours
+  
+* [The Social-Engineer Podcast](http://www.social-engineer.org/category/podcast/)
+  * **Description**: The Social-Engineer Podcast is about humans. Understanding how we interact, communicate and relay information can help us protect, mitigate and understand social engineering attacks
+  * **Frequency**: Monthly
+  * **Runtime**: Approximately 60 mins
+  
+* [Unsupervised Learning](https://danielmiessler.com/podcast/)
+  * **Description**: I spend between five and twenty hours a week consuming articles, books, and podcasts looking for the most interesting ideas around security, technology, and how they interact with us as humans. Each episode is either a curated summary of what I’ve found in the past week, or a standalone essay that hopefully gives you something to think about.
+  * **Frequency**: Usually 15 - 30 mins, sometimes up to an hour
+  * **Runtime**: Bi-Weekly, Weekly for subscribers
+  
 ## Swift
 
 * [Fireside Swift](https://itunes.apple.com/us/podcast/fireside-swift/id1269435221?mt=2)


### PR DESCRIPTION
I've added some awesome infosec podcasts to the list :) 

### Things to do:

- [x] Add podcasts in appropriate categories in ascending order of podcast name
- [x] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
- [x] Add a brief description of the podcast
- [x] Add the frequency of episodes (Check the list for examples)
- [x] Add the runtime of episodes, giving an approximate range and an average duration.

Thanks for your contributions and being awesome :) Cheers.
