### PR TITLE
Add Host information for the .NET section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ List of podcasts which are helpful for software engineers/programmers.
 * [HERDING CODE](http://herdingcode.com)
 
   * **Description**: show covering a broad range of .NET-related topics in considerable technical depth.
+  * **Host**: K. Scott Allen @[OdeToCode](https://twitter.com/OdeToCode), Kevin Dente, Scott Koon, Jon Galloway @[jongalloway](https://twitter.com/jongalloway)
   * **Frequency**: Monthly once
   * **Runtime**: 15 - 60 mins, regularly ~55 mins
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ List of podcasts which are helpful for software engineers/programmers.
 
 * [Gone Mobile](https://www.gonemobile.io/)
   * **Description**: A podcast discussing the latest in mobile development, with a healthy bias towards Xamarin technologies. The podcast covers in-depth topics with guests ranging from Android, iOS & Windows development to mobile marketing and design.
+  * **Host**: Greg Shackles @[gshackles](https://twitter.com/gshackles), Jon Dick @[redth.codes](https://twitter.com/redth)
   * **Frequency**: Varies
   * **Runtime**: 30 - 60 mins, regularly ~45 mins
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ List of podcasts which are helpful for software engineers/programmers.
 
 * [Merge Conflict](http://www.mergeconflict.fm/)
   * **Description**: Join Frank & James for a weekly discussion on the world of technology and development including C#, F#, .NET, web, mobile, and more.
+  * **Host**: Frank Krueger @[praeclarum](https://twitter.com/praeclarum), James Montemagno @[JamesMontemagno](https://twitter.com/jamesmontemagno)
   * **Frequency**: Weekly
   * **Runtime**: 30 - 60 mins, regularly ~45 mins
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ List of podcasts which are helpful for software engineers/programmers.
 * [.NET Rocks](https://www.dotnetrocks.com/) ([Stitcher](https://www.stitcher.com/podcast/net-rocks))
 
   * **Description**: .NET Rocks! is a weekly talk show for anyone interested in programming on the Microsoft .NET platform. The shows range from introductory information to hardcore geekiness.
+  * **Host**: Carl Franklin @[carlfranklin](https://twitter.com/carlfranklin), Richard Campbell @[richcampbell](https://twitter.com/richcampbell)
   * **Frequency**: Two episodes every week
   * **Runtime**: 45 - 60 mins, regularly ~60 mins
 


### PR DESCRIPTION
Add the Host information for all the podcasts in the .NET section.

Before raising a PR and it getting merged, make sure you have completed the following:

### Things to do:

- [ ] Add podcasts in appropriate categories in ascending order of podcast name
- [ ] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
- [ ] Add a brief description of the podcast
- [ ] Add the frequency of episodes (Check the list for examples)
- [ ] Add the runtime of episodes, giving an approximate range and an average duration.



Thanks for your contributions and being awesome :) Cheers.
