### PR TITLE
Add "Hipsters Ponto Tech"

### DIFF
--- a/PT.md
+++ b/PT.md
@@ -37,3 +37,9 @@ Uma lista de podcasts que podem ser úteis para programadores e engenheiros de s
   * **Descrição**: Tópicos gerais sobre desenvolvimento de software, frontend, javascript
   * **Frequência**: Normalmente 2 vezes por mês
   * **Duração**: 30 - 45 min
+  
+  
+* [Hipsters Ponto Tech](https://hipsters.tech/)
+  * **Descrição**: Tópicos gerais sobre programação, design, ux, gadgets, startups, etc
+  * **Frequência**: Zemanal
+  * **Duração**: 40 - 50 min


### PR DESCRIPTION
From "Hipsters Ponto Tech" 's site:
> "O Hipsters Ponto Tech é o podcast onde o pessoal da Caelum e da Alura entra em discussões acaloradas sobre programação,
> design, ux, gadgets, startups e as últimas modinhas em tecnologia. Ah! E sempre com convidados."

## Translate from Google:

> "Hipsters Ponto Tech is the podcast where Caelum and Alura people enter into heated discussions about programming, design, ux,
> gadgets, startups and the latest technology trends. Ah! And always with guests."

Before raising a PR and it getting merged, make sure you have completed the following:

### Things to do:

- [ ] Add podcasts in appropriate categories in ascending order of podcast name
- [ ] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
- [ ] Add a brief description of the podcast
- [ ] Add the frequency of episodes (Check the list for examples)
- [ ] Add the runtime of episodes, giving an approximate range and an average duration.

Thanks for your contributions and being awesome :) Cheers.
