### PR TITLE
Add "Friday Afternoon Deploy"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1196,6 +1196,12 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Frequency**: Various
   * **Runtime**: 15 - 60 mins, regularly ~30 mins
 
+* [Friday Afternoon Deploy](https://friday.hirelofty.com/) ([iTunes](https://itunes.apple.com/us/podcast/friday-afternoon-deploy/id1441215128?mt=2&l=en) | [Spotify](https://open.spotify.com/show/61A2PUqpAI4lkdBVeMUjEP?si=lEzrpUfCS-yGNH9lJNkoMw) | [RSS](https://feeds.buzzsprout.com/223293.rss))
+  * **Description**: A podcast about the culture and chaos of software engineering. @LoftyLabs devs make software then discuss our regrets on Fridays.
+  * **Host**:Tyrel Denison @[tyreldenison](https://twitter.com/tyreldenison), Casey Kinsey @[quesokinsey](https://twitter.com/quesokinsey), Alan Fraley and Hayden Luckenbach
+  * **Frequency**: Once every week
+  * **Runtime**: 50 - 70 mins, regularly ~60 mins
+
 ## R
 
 * [The R-Podcast](https://r-podcast.org/)

--- a/README.md
+++ b/README.md
@@ -1170,6 +1170,12 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
 
 ## Python
 
+* [Friday Afternoon Deploy](https://friday.hirelofty.com/) ([iTunes](https://itunes.apple.com/us/podcast/friday-afternoon-deploy/id1441215128?mt=2&l=en) | [Spotify](https://open.spotify.com/show/61A2PUqpAI4lkdBVeMUjEP?si=lEzrpUfCS-yGNH9lJNkoMw) | [RSS](https://feeds.buzzsprout.com/223293.rss))
+  * **Description**: A podcast about the culture and chaos of software engineering. @LoftyLabs devs make software then discuss our regrets on Fridays.
+  * **Host**:Tyrel Denison @[tyreldenison](https://twitter.com/tyreldenison), Casey Kinsey @[quesokinsey](https://twitter.com/quesokinsey), Alan Fraley and Hayden Luckenbach
+  * **Frequency**: Once every week
+  * **Runtime**: 50 - 70 mins, regularly ~60 mins
+  
 * [Podcast.\_\_init\_\_](https://pythonpodcast.com/)
 
   * **Description**: The Podcast About Python and the People Who Make It Great
@@ -1195,12 +1201,6 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Host**: Brian Okken @[brianokken](https://twitter.com/brianokken)
   * **Frequency**: Various
   * **Runtime**: 15 - 60 mins, regularly ~30 mins
-
-* [Friday Afternoon Deploy](https://friday.hirelofty.com/) ([iTunes](https://itunes.apple.com/us/podcast/friday-afternoon-deploy/id1441215128?mt=2&l=en) | [Spotify](https://open.spotify.com/show/61A2PUqpAI4lkdBVeMUjEP?si=lEzrpUfCS-yGNH9lJNkoMw) | [RSS](https://feeds.buzzsprout.com/223293.rss))
-  * **Description**: A podcast about the culture and chaos of software engineering. @LoftyLabs devs make software then discuss our regrets on Fridays.
-  * **Host**:Tyrel Denison @[tyreldenison](https://twitter.com/tyreldenison), Casey Kinsey @[quesokinsey](https://twitter.com/quesokinsey), Alan Fraley and Hayden Luckenbach
-  * **Frequency**: Once every week
-  * **Runtime**: 50 - 70 mins, regularly ~60 mins
 
 ## R
 


### PR DESCRIPTION
Heya 👋 ,

Friday Afternoon Deploy is a podcast about the culture and chaos of software engineering. Special thanks to @tyreldenison , @ckinsey , @aFraley and @hayfever for making the Podcast happen.

### Things to do:

- [x] Add podcasts in appropriate categories in ascending order of podcast name
- [x] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
- [x] Add a brief description of the podcast
- [x] Add the frequency of episodes (Check the list for examples)
- [x] Add the runtime of episodes, giving an approximate range and an average duration.
