### PR TITLE
Add devMode.fm to Web Development podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1516,7 +1516,7 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Frequency**: Approximately once a month
   * **Runtime**: 25 - 75 mins, regularly ~50 mins
   
-* devMode.fm ([iTunes](https://itunes.apple.com/us/podcast/devmode-fm/id1323364824?mt=2) | [Google Play](https://play.google.com/music/m/Ijjc3udlxfsiqqilxxs7k2pqrbu?t=devModefm))
+* [devMode.fm](https://devmode.fm/) ([iTunes](https://itunes.apple.com/us/podcast/devmode-fm/id1323364824?mt=2) | [Google Play](https://play.google.com/music/m/Ijjc3udlxfsiqqilxxs7k2pqrbu?t=devModefm))
 
   * **Description**: a bi-weekly podcast dedicated to the tools, techniques, and technologies used in modern web development.
   * **Host**: Andrew Welch @[nystudio107](https://twitter.com/nystudio107), Patrick Harrington @[p_harrington83](https://twitter.com/p_harrington83), Jonathan Melville @[jonmelville](https://twitter.com/jonmelville), Michael Rog @[michaelrog](https://twitter.com/michaelrog), Earl Johnston, Marion Newlevant @[marionnewlevant](https://twitter.com/marionnewlevant), Lauren Dorman @[laurendorman](https://twitter.com/laurendorman) and Matt Stein @[mattrambles](https://twitter.com/mattrambles)  

--- a/README.md
+++ b/README.md
@@ -1515,6 +1515,13 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Host**: David Hemphil @[davidhemphill](https://twitter.com/davidhemphill), Andrew Del Prete @[AndrewDelPrete](https://twitter.com/AndrewDelPrete)
   * **Frequency**: Approximately once a month
   * **Runtime**: 25 - 75 mins, regularly ~50 mins
+  
+* devMode.fm ([iTunes](https://itunes.apple.com/us/podcast/devmode-fm/id1323364824?mt=2) | [Google Play](https://play.google.com/music/m/Ijjc3udlxfsiqqilxxs7k2pqrbu?t=devModefm))
+
+  * **Description**: a bi-weekly podcast dedicated to the tools, techniques, and technologies used in modern web development.
+  * **Host**: Andrew Welch @[nystudio107](https://twitter.com/nystudio107), Patrick Harrington @[p_harrington83](https://twitter.com/p_harrington83), Jonathan Melville @[jonmelville](https://twitter.com/jonmelville), Michael Rog @[michaelrog](https://twitter.com/michaelrog), Earl Johnston, Marion Newlevant @[marionnewlevant](https://twitter.com/marionnewlevant), Lauren Dorman @[laurendorman](https://twitter.com/laurendorman) and Matt Stein @[mattrambles](https://twitter.com/mattrambles)  
+  * **Frequency**: Bi-weekly
+  * **Runtime**: 50 - 60 mins, regularly ~50 mins
 
 * Does Not Compute ([By Spec](https://spec.fm/podcasts/does-not-compute) | [iTunes](https://itunes.apple.com/us/podcast/does-not-compute/id1048731980?mt=2))
 


### PR DESCRIPTION
Before raising a PR and it getting merged, make sure you have completed the following:

### Things to do:

- [x] Add podcasts in appropriate categories in ascending order of podcast name
- [ ] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
- [x] Add a brief description of the podcast
- [x] Add the frequency of episodes (Check the list for examples)
- [x] Add the runtime of episodes, giving an approximate range and an average duration.

Thanks for your contributions and being awesome :) Cheers.
