### PR TITLE
Corrected host info on 2 podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,13 +616,14 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
 * [Complete Developer Podcast](http://completedeveloperpodcast.com)
 
   * **Description**: Listen to a senior developer and a junior developer discuss topics about all aspects of software development from the highly technical, to patterns and principles, to soft skills.
+  * **Host**: Will Gant @[gantsoftsys](https://twitter.com/gantsoftsys), BJ Burns @[bowtiebeej]
   * **Frequency**: Every Thursday
   * **Runtime**: 40 - 65 mins, regularly ~60 mins
 
 * [Command Line Heroes](https://www.redhat.com/en/command-line-heroes)
 
   * **Description**: Command Line Heroes tells the epic true tales of how developers, programmers, hackers, geeks, and open source rebels are revolutionizing the technology landscape.
-  * **Host**: Will Gant @[gantsoftsys](https://twitter.com/gantsoftsys), BJ Burns @[bowtiebeej](https://twitter.com/bowtiebeej)
+  * **Host**: Saron Yitbarek @[saronyitbarek]
   * **Frequency**: Twice per month
   * **Runtime**: 25 - 30 mins, regularly ~30 mins
 


### PR DESCRIPTION
Hosts for Complete Developer Podcast were put under the Command Line Heroes podcast. I moved the host info for the former, and added the correct host for the latter.

Before raising a PR and it getting merged, make sure you have completed the following:

### Things to do:

- [ ] Add podcasts in appropriate categories in ascending order of podcast name
- [ ] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
- [ ] Add a brief description of the podcast
- [ ] Add the frequency of episodes (Check the list for examples)
- [ ] Add the runtime of episodes, giving an approximate range and an average duration.

Thanks for your contributions and being awesome :) Cheers.
