### PR TITLE
added DevCouch a german .NET podcast

### DIFF
--- a/DE.md
+++ b/DE.md
@@ -5,6 +5,7 @@ Eine Liste von Podcasts, die hilfreich für Software Entwickler und Programmiere
 ## Übersicht
 
 * [Allgemein](#allgemein)
+* [.NET](#net)
 * [Agile](#agile)
 * [Webentwicklung](#webentwicklung)
 
@@ -27,6 +28,16 @@ Eine Liste von Podcasts, die hilfreich für Software Entwickler und Programmiere
   * **Twitter**: [@repod_at](https://twitter.com/repod_at)
   * **Gastgeber**: [Christian Leo-Pernold](https://twitter.com/mazedlx) und [Franky Luef](https://twitter.com/federic0green)
 
+## .NET
+
+* [DevCouch](https://devcouch.de/) ([RSS](https://devcouch.de/podcast/feed/))
+
+  * **Beschreibung**: Der deutschsprachige Podcast für .NET Entwickler.
+  * **Häufigkeit**: circa alle 14 Tage
+  * **Laufzeit**: 60 - 90 min, regulär ~80 min
+  * **Twitter**: [@_devcouch](https://twitter.com/_devcouch)
+  * **Gastgeber**: Manuel Wenk [@Argbeil](https://twitter.com/Argbeil), Thomas Krause, Oliver Vogel [@heisenbird](https://twitter.com/heisenbird)
+  
 ## Agile
 
 * [Mein Scrum ist kaputt!](https://meinscrumistkaputt.de/)


### PR DESCRIPTION
Added a german .NET podcast to the new .NET category

Before raising a PR and it getting merged, make sure you have completed the following:

### Things to do:

- [x] Add podcasts in appropriate categories in ascending order of podcast name
- [x] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
- [x] Add a brief description of the podcast
- [x] Add a host of the podcast (optional if hosted by group or panel)
- [x] Add the frequency of episodes (check the list for examples)
- [x] Add the runtime of episodes, giving an approximate range and an average duration

Thanks for your contributions and being awesome :) Cheers.
