### PR TITLE
Added a German podcast

### DIFF
--- a/DE.md
+++ b/DE.md
@@ -26,6 +26,13 @@ Eine Liste von Podcasts, die hilfreich für Software Entwickler und Programmiere
   * **Laufzeit**: 15 - 60 Minuten
   * **Twitter**: [@repod_at](https://twitter.com/repod_at)
   * **Gastgeber**: [Christian Leo-Pernold](https://twitter.com/mazedlx) und [Franky Luef](https://twitter.com/federic0green)
+  
+* [SoftwareArchitekTOUR](https://www.heise.de/developer/SoftwareArchitekTOUR-4076349.html) ([RSS](https://www.heise.de/developer/rss/podcast-softwarearchitektour.rss))
+  
+  * **Beschreibung**: Ein Podcast über Softwarearchitektur von bekannten Softwareentwicklern.
+  * **Häufigkeit**: Unregelmäßig
+  * **Laufzeit**: knapp 60 min
+  * **Gastgeber**: heise Developer Redaktion mit [Gastsprechern](https://www.heise.de/developer/SoftwareArchitekTOUR-4076983.html)
 
 ## Agile
 


### PR DESCRIPTION
Added a German podcast that focuses on software architecture and is presented by a group of (somewhat) well known group of engineers (publishing articles in magazines, speaking at conventions etc.)

### Things to do:

- [X] Add podcasts in appropriate categories in ascending order of podcast name
- [X] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
- [X] Add a brief description of the podcast
- [X] Add a host of the podcast (optional if hosted by group or panel)
- [X] Add the frequency of episodes (check the list for examples)
- [X] Add the runtime of episodes, giving an approximate range and an average duration