### PR TITLE
Add Django Chat podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ List of podcasts which are helpful for software engineers/programmers.
 * [PHP](#php)
   * [Laravel](#laravel)
 * [Python](#python)
+  * [Django](#django)
 * [R](#R)
 * [ReasonML](#reasonml)
 * [Ruby/Rails](#rubyrails)
@@ -1388,6 +1389,15 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Host**: Brian Okken @[brianokken](https://twitter.com/brianokken)
   * **Frequency**: Various
   * **Runtime**: 15 - 60 mins, regularly ~30 mins
+
+### Django
+
+* [Django Chat](https://djangochat.com/) ([iTunes](https://podcasts.apple.com/us/podcast/django-chat/id1451536459))
+
+  * **Description**: A weekly podcast on the Django Web Framework.
+  * **Host**: William Vincent @[wsv3000](https://twitter.com/wsv3000), Carlton Gibson @[carltongibson](https://twitter.com/carltongibson)
+  * **Frequency**: Once a week
+  * **Runtime**: 20 - 60 mins, regularly ~40 mins
 
 ## R
 


### PR DESCRIPTION
Before raising a PR and it getting merged, make sure you have completed the following:

### Things to do:

- [x] Add podcasts in appropriate categories in ascending order of podcast name
- [x] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
- [x] Add a brief description of the podcast
- [x] Add a host of the podcast (optional if hosted by group or panel)
- [x] Add the frequency of episodes (check the list for examples)
- [x] Add the runtime of episodes, giving an approximate range and an average duration

Thanks for your contributions and being awesome :) Cheers.
