### PR TITLE
Docplanner tech talks

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
 * [Docplanner Tech Talks](https://anchor.fm/docplanner-tech-talks)
 
   * **Description**: Welcome to our Docplanner Tech Talks - podcast, which is our way to share knowledge and become closer to the Tech community.
+  * **Host**: Przemysław Paczoski @[kodziak](https://www.linkedin.com/in/ppaczoski/)
   * **Frequency**: Once a month
   * **Runtime**: 15 - 30 mins, regularly ~20 mins
 

--- a/README.md
+++ b/README.md
@@ -788,6 +788,12 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Frequency**: Every Monday, Wednesday and Friday
   * **Runtime**: 10 - 50 mins, regularly ~20 mins
 
+* [Docplanner Tech Talks](https://anchor.fm/docplanner-tech-talks)
+
+  * **Description**: Welcome to our Docplanner Tech Talks - podcast, which is our way to share knowledge and become closer to the Tech community.
+  * **Frequency**: Once a month
+  * **Runtime**: 15 - 30 mins, regularly ~20 mins
+
 * [Eat Sleep Code](https://developer.telerik.com/community/eat-sleep-code/)
 
   * **Description**: The Official Telerik Podcast. They interview "passionate people about a wide range of developer related topics."


### PR DESCRIPTION
Adding "Docplanner Tech Talks" to General Software.

### Things to do:

- [x] Add podcasts in appropriate categories in ascending order of podcast name
- [x] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
- [x] Add a brief description of the podcast
- [x] Add a host of the podcast (optional if hosted by group or panel)
- [x] Add the frequency of episodes (check the list for examples)
- [x] Add the runtime of episodes, giving an approximate range and an average duration

Thanks for your contributions and being awesome :) Cheers.
