### PR TITLE
Added Spotify links for the Django podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1549,14 +1549,14 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
 
 ### Django
 
-* [Django Chat](https://djangochat.com/) ([iTunes](https://podcasts.apple.com/us/podcast/django-chat/id1451536459))
+* [Django Chat](https://djangochat.com/) ([iTunes](https://podcasts.apple.com/us/podcast/django-chat/id1451536459), [Spotify](https://open.spotify.com/show/4JTUPoJhFKOjbzNbGmIq5l?si=92c19ad7d7cc4bd6))
 
   * **Description**: A weekly podcast on the Django Web Framework.
   * **Host**: William Vincent @[wsv3000](https://twitter.com/wsv3000), Carlton Gibson @[carltongibson](https://twitter.com/carltongibson)
   * **Frequency**: Once a week
   * **Runtime**: 20 - 60 mins, regularly ~40 mins
 
-* [Django-Riffs](https://www.mattlayman.com/django-riffs/) ([iTunes](https://podcasts.apple.com/us/podcast/django-riffs/id1497248397))
+* [Django-Riffs](https://www.mattlayman.com/django-riffs/) ([iTunes](https://podcasts.apple.com/us/podcast/django-riffs/id1497248397), [Spotify](https://open.spotify.com/show/1RtdveQIz5m5MqLKPWbhnD?si=9ae04ec16dda474d))
 
   * **Description**: Django Riffs is a podcast for learning web application development in Python using the Django web framework. We explore all of Django's features to equip listeners with the knowledge to build a web app.
   * **Host**: Matt Layman @[@mblayman](https://twitter.com/mblayman))


### PR DESCRIPTION
Added Spotify links for Django Chat and Django Riffs

Before raising a PR and it getting merged, make sure you have completed the following:

### Things to do:

- [x] Add podcasts in appropriate categories in ascending order of podcast name
- [x] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
- [x] Add a brief description of the podcast
- [x] Add a host of the podcast (optional if hosted by group or panel)
- [x] Add the frequency of episodes (check the list for examples)
- [x] Add the runtime of episodes, giving an approximate range and an average duration

Thanks for your contributions and being awesome :) Cheers.
