### PR TITLE
[DE] Add Computer und Kommunikation Podast

### DIFF
--- a/DE.md
+++ b/DE.md
@@ -21,11 +21,18 @@ Eine Liste von Podcasts, die hilfreich für Software Entwickler und Programmiere
 
 * [Codestammtisch](https://codestammtis.ch) ([RSS](https://codestammtis.ch/feed/mp3/), [Spotify](https://open.spotify.com/show/1q3dDiYvXHcMaDFopGt3Mh), [iTunes](https://itunes.apple.com/ch/podcast/codestammtisch/id1410854302?l=en&mt=2))
 
-  * **Beschreibung**: Ein Getränk lang Irgendwas mit Softwareentwicklung.
+  * **Beschreibung**: 
   * **Häufigkeit** : Jeden 2. Montag um 19:00 Uhr
   * **Laufzeit**: 1 Getränk (30 - 45 Minuten)
   * **Twitter**: [@codestammtisch](https://twitter.com/codestammtisch)
   * **Gastgeber**: [Maximilian Koch](https://twitter.com/tschaka1904) & [Nathan Mattes](https://twitter.com/zeitschlag)
+
+* [Computer und Kommunikation - Sendung - Deutschlandfunk](https://www.deutschlandfunk.de/computer-und-kommunikation-102.xml) ([RSS](https://www.deutschlandfunk.de/computer-und-kommunikation-100.rss), [Spotify](https://open.spotify.com/show/4uy56W83RGe8SKmzNpyfAc?si=d903700bd6754551), [iTunes](https://podcasts.apple.com/de/podcast/computer-und-kommunikation-sendung-deutschlandfunk/id173754605))
+
+  * **Beschreibung**: Das Neueste aus Computertechnik und Informationstechnologie. Beiträge, Reportagen und Interviews zu IT-Sicherheit, Informatik, Datenschutz, Smartphones, Cloud-Computing und IT-Politik. Die Trends der IT werden kompakt und informativ zusammengefasst.
+  * **Häufigkeit** : Jeden Samstag
+  * **Laufzeit**: 30 min
+  * **Gastgeber**: [Manfred Kloiber](https://twitter.com/radioklicker?lang=gl)
 
 * [INNOQ Podcast](https://www.innoq.com/de/podcast/) ([RSS](https://innoq.podigee.io/feed/aac))
   


### PR DESCRIPTION
Add [DE] Computer und Kommunikation Podcast

### Things to do:

- [ X] Add podcasts in appropriate categories in ascending order of podcast name
- [ X] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
- [ X] Add a brief description of the podcast
- [ X] Add a host of the podcast (optional if hosted by group or panel)
- [ X] Add the frequency of episodes (check the list for examples)
- [X ] Add the runtime of episodes, giving an approximate range and an average duration

Before raising a PR and it getting merged, make sure you have completed the following:

### Things to do:

- [ ] Add podcasts in appropriate categories in ascending order of podcast name
- [ ] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
- [ ] Add a brief description of the podcast
- [ ] Add a host of the podcast (optional if hosted by group or panel)
- [ ] Add the frequency of episodes (check the list for examples)
- [ ] Add the runtime of episodes, giving an approximate range and an average duration

Thanks for your contributions and being awesome :) Cheers.
