### PR TITLE
Add Women in Analytics After Hours podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,14 @@ More .NET Podcasts can be found on [The Sound of .NET](https://thesoundof.net/)
   * **Frequency**: Twice a week
   * **Runtime**: 30 - 60 mins, regularly ~45 mins
 
+* [Women in Analytics After Hours](https://www.womeninanalytics.com/podcast)
+
+  * **Description**: Connects with women in all areas of data and analytics to talk about what they do in the space, how they got there, where they found data along the way, and more.
+  * **Host**: Lauren Burke @[lauren_e_burke](https://twitter.com/lauren_e_burke)
+  * **Frequency**: Every three weeks
+  * **Runtime**: 30 - 60 mins, regularly ~45 mins
+
+
 ## Devops
 
 * [Adventures in DevOps](https://devchat.tv/adventures-in-devops/)


### PR DESCRIPTION
Adding Women in Analytics After Hours podcast, which covers data, ml, AI topics with women in the field.

Before raising a PR and it getting merged, make sure you have completed the following:

### Things to do:

- [x ] Add podcasts in appropriate categories in ascending order of podcast name
- [ ] If there is no matching category, add a new category to the list in ascending order of category name, and add it to the table of contents in the same order
- [ x] Add a brief description of the podcast
- [ x] Add a host of the podcast (optional if hosted by group or panel)
- [x ] Add the frequency of episodes (check the list for examples)
- [ x] Add the runtime of episodes, giving an approximate range and an average duration

Thanks for your contributions and being awesome :) Cheers.
